### PR TITLE
Moved from dockerhub to ghcr for simplicity

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,38 +1,49 @@
-name: Build cloudflare-ddns Docker image (multi-arch)
+name: Build cloudflare-ddns Docker image (multi-arch) straight to GitHub
 
 on:
   push:
     branches: master
   pull_request:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      # https://github.com/docker/setup-qemu-action
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      # https://github.com/docker/setup-buildx-action
+
       - name: Setting up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: timothyjmiller/cloudflare-ddns
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           sep-tags: ','
           flavor: |
             latest=false
@@ -40,8 +51,9 @@ jobs:
             type=raw,enable=${{ steps.extract_branch.outputs.branch == 'master' }},value=latest
             type=schedule
             type=ref,event=pr
-            
+
       - name: Build and publish
+        id: build_and_publish
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -52,3 +64,11 @@ jobs:
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Generate artifact attestation
+        #if: github.ref == 'refs/heads/master'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-path: ${{ github.workspace }}/Dockerfile
+          push-to-registry: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for building the Cloudflare DDNS Docker image. The changes focus on improving the image build process and enhancing security by using the GitHub Container Registry and generating artifact attestations.

### Workflow improvements:

* [`.github/workflows/image.yml`](diffhunk://#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6L1-R46): Updated the workflow to build the Docker image directly to GitHub Container Registry instead of DockerHub.
* [`.github/workflows/image.yml`](diffhunk://#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6L1-R46): Added environment variables for `REGISTRY` and `IMAGE_NAME` to streamline the configuration.
* [`.github/workflows/image.yml`](diffhunk://#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6L1-R46): Updated the login step to use GitHub credentials for authentication with the GitHub Container Registry.

### Security enhancements:

* [`.github/workflows/image.yml`](diffhunk://#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6L1-R46): Added permissions for `contents`, `packages`, `attestations`, and `id-token` to the `build` job to enhance security.
* [`.github/workflows/image.yml`](diffhunk://#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6R66-R72): Added a step to generate artifact attestations using the `actions/attest-build-provenance@v2` action.