### PR TITLE
feat: added new release mechanism

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master]
   pull_request:
+  release:
+    types: [published]  # Trigger on new GitHub releases
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master  # Only trigger when changes are merged into master
+  workflow_dispatch:
+
+permissions:
+  contents: write  # Needed for creating tags/releases
+  pull-requests: write  # Needed for PRs that update versions
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for full commit history
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Run Release Please
+        uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
+          bump-minor-pre-major: true  # Minor bumps for pre-1.0.0
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflows, specifically adding a new release workflow and modifying the existing image workflow to trigger on new GitHub releases. 

Changes to GitHub Actions workflows:

* [`.github/workflows/image.yml`](diffhunk://#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6R7-R8): Added a trigger for new GitHub releases to the existing workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R32): Added a new workflow for handling releases that includes setting up Node.js, checking out the repository, and running the Release Please action.