### PR TITLE
chore: add version tags to images

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -56,7 +56,10 @@ jobs:
         with:
           context: .
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            latest
+            ${{ github.event.release.tag_name }}
           platforms: linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}


### PR DESCRIPTION
This pull request to the `.github/workflows/image.yml` file includes changes to enhance the Docker image tagging process in the CI/CD pipeline. The most important change is the addition of new tags for the Docker images, which include the registry and image name, as well as the release tag name.

Enhancements to Docker image tagging:

* [`.github/workflows/image.yml`](diffhunk://#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6L59-R62): Added new tags to include the registry and image name, and the release tag name to the Docker image tags.